### PR TITLE
Fixes generation for heroic tragedy

### DIFF
--- a/Basic Example/Basic Parse & Search.cs
+++ b/Basic Example/Basic Parse & Search.cs
@@ -1,9 +1,6 @@
 //notables are a dictionary of notable index and weight
 //stats are a dictionary of stat index and weight
-//definitions for both can be found at https://github.com/Regisle/TimelessJewelData
-//if Elegant Hubris & Militant Faith aren't working, try swapping their file names
-//there was a mixup with jewel type indices earlier that had them named backward the first time they were uploaded
-//and you might have the outdated names still
+//definitions for both notable and stat indices can be found at https://github.com/Regisle/TimelessJewelData
 private static IEnumerable<Tuple<int, double>> ExecuteNonGVSearch(Dictionary<int, double> notables, Dictionary<int, double> stats, double weight, int jewelType)
 {
     //DisplayInputs(notables, stats, weight, jewelType); pretty printed the inputs
@@ -34,6 +31,10 @@ private static IEnumerable<Tuple<int, double>> ExecuteNonGVSearch(Dictionary<int
             minSeed = 2000;
             maxSeed = 160000;
             seedIncrement = 20;
+            break;
+        case 6:
+            minSeed = 100;
+            maxSeed = 8000;
             break;
         default:
             break;
@@ -72,8 +73,6 @@ private static IEnumerable<Tuple<int, double>> ExecuteNonGVSearch(Dictionary<int
     Console.WriteLine("jewel seeds & weight:\n" + string.Join("\n", searchResult.Select(x => $"(seed: {string.Format("{0,6}", x.Item1)}\tweight: {x.Item2})")));
     return searchResult;
 }
-
-
 
 private static IEnumerable<Tuple<int, double>> ExecuteGVSearch(Dictionary<int, double> notables, Dictionary<int, double> stats, double weight)
 {
@@ -132,28 +131,28 @@ private static IEnumerable<Tuple<int, double>> ExecuteGVSearch(Dictionary<int, d
     return new List<Tuple<int, double>>();
 }
 
-
-
-
 private static FileStream? GetStreamForJewel(int jewelType)
 {
     string fileName;
     switch (jewelType)
     {
         case 1:
-            fileName = @"Glorious Vanity";
+            fileName = "GloriousVanity";
             break;
         case 2:
-            fileName = @"Lethal Pride";
+            fileName = "LethalPride";
             break;
         case 3:
-            fileName = @"Brutal Restraint";
+            fileName = "BrutalRestraint";
             break;
         case 4:
-            fileName = @"Militant Faith";
+            fileName = "MilitantFaith";
             break;
         case 5:
-            fileName = @"Elegant Hubris";
+            fileName = "ElegantHubris";
+            break;
+        case 6:
+            fileName = "HeroicTragedy";
             break;
         default:
             return null;

--- a/Datafile Generator/DatafileGenerator/Source/Data/DataManager.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/DataManager.cs
@@ -37,7 +37,8 @@ public static class DataManager
             new AlternateTreeVersion(2),
             new AlternateTreeVersion(3),
             new AlternateTreeVersion(4),
-            new AlternateTreeVersion(5)
+            new AlternateTreeVersion(5),
+            new AlternateTreeVersion(6)
         };
 
     public static List<AlternatePassiveAddition> GetApplicableAlternatePassiveAdditions(PassiveSkill passiveSkill, TimelessJewel timelessJewel)

--- a/Datafile Generator/DatafileGenerator/Source/Data/Models/AlternatePassiveSkill.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/Models/AlternatePassiveSkill.cs
@@ -15,28 +15,28 @@ public class AlternatePassiveSkill
     public IReadOnlyCollection<uint> StatIndices { get; init; }
 
     [JsonPropertyName("Stat1Min")]
-    public uint StatAMinimumValue { get; init; }
+    public int StatAMinimumValue { get; init; }
 
     [JsonPropertyName("Stat1Max")]
-    public uint StatAMaximumValue { get; init; }
+    public int StatAMaximumValue { get; init; }
 
     [JsonPropertyName("Stat2Min")]
-    public uint StatBMinimumValue { get; init; }
+    public int StatBMinimumValue { get; init; }
 
     [JsonPropertyName("Stat2Max")]
-    public uint StatBMaximumValue { get; init; }
+    public int StatBMaximumValue { get; init; }
 
     [JsonPropertyName("Unknown10")]
-    public uint StatCMinimumValue { get; init; }
+    public int StatCMinimumValue { get; init; }
 
     [JsonPropertyName("Unknown11")]
-    public uint StatCMaximumValue { get; init; }
+    public int StatCMaximumValue { get; init; }
 
     [JsonPropertyName("Unknown12")]
-    public uint StatDMinimumValue { get; init; }
+    public int StatDMinimumValue { get; init; }
 
     [JsonPropertyName("Unknown13")]
-    public uint StatDMaximumValue { get; init; }
+    public int StatDMaximumValue { get; init; }
 
     [JsonPropertyName("PassiveType")]
     public IReadOnlyCollection<uint> ApplicablePassiveTypes { get; init; }

--- a/Datafile Generator/DatafileGenerator/Source/Data/Models/AlternateTreeVersion.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/Models/AlternateTreeVersion.cs
@@ -9,6 +9,7 @@ public class AlternateTreeVersion
         3 => false,
         4 => true,
         5 => true,
+        6 => false,
         _ => false
     };
     public bool AreSmallNormalPassiveSkillsReplaced => Index switch
@@ -18,6 +19,7 @@ public class AlternateTreeVersion
         3 => false,
         4 => false,
         5 => true,
+        6 => false,
         _ => false
     };
     public uint MinimumAdditions => Index switch
@@ -27,6 +29,7 @@ public class AlternateTreeVersion
         3 => 1,
         4 => 1,
         5 => 0,
+        6 => 0,
         _ => 0
     };
     public uint MaximumAdditions => Index switch
@@ -36,6 +39,7 @@ public class AlternateTreeVersion
         3 => 1,
         4 => 1,
         5 => 0,
+        6 => 0,
         _ => 0
     };
     public uint NotableReplacementSpawnWeight => Index switch
@@ -45,6 +49,7 @@ public class AlternateTreeVersion
         3 => 0,
         4 => 20,
         5 => 100,
+        6 => 100,
         _ => 0
     };
 

--- a/Datafile Generator/DatafileGenerator/Source/Game/AlternatePassiveSkillInformation.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Game/AlternatePassiveSkillInformation.cs
@@ -8,11 +8,11 @@ public class AlternatePassiveSkillInformation
 {
     public AlternatePassiveSkill AlternatePassiveSkill { get; private set; }
 
-    public IReadOnlyDictionary<uint, uint> StatRolls { get; private set; }
+    public IReadOnlyDictionary<uint, int> StatRolls { get; private set; }
 
     public IReadOnlyCollection<AlternatePassiveAdditionInformation> AlternatePassiveAdditionInformations { get; private set; }
 
-    public AlternatePassiveSkillInformation(AlternatePassiveSkill alternatePassiveSkill, IReadOnlyDictionary<uint, uint> statRolls, IReadOnlyCollection<AlternatePassiveAdditionInformation> alternatePassiveAdditionInformations)
+    public AlternatePassiveSkillInformation(AlternatePassiveSkill alternatePassiveSkill, IReadOnlyDictionary<uint, int> statRolls, IReadOnlyCollection<AlternatePassiveAdditionInformation> alternatePassiveAdditionInformations)
     {
         ArgumentNullException.ThrowIfNull(alternatePassiveSkill, nameof(alternatePassiveSkill));
         ArgumentNullException.ThrowIfNull(statRolls, nameof(statRolls));

--- a/Datafile Generator/DatafileGenerator/Source/Game/AlternateTreeManager.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Game/AlternateTreeManager.cs
@@ -50,7 +50,7 @@ public class AlternateTreeManager
         if (PassiveSkill.IsKeyStone)
         {
             AlternatePassiveSkill alternatePassiveSkillKeyStone = DataManager.GetAlternatePassiveSkillKeyStone(TimelessJewel);
-            Dictionary<uint, uint> alternatePassiveSkillKeyStoneStatRolls = new Dictionary<uint, uint>()
+            Dictionary<uint, int> alternatePassiveSkillKeyStoneStatRolls = new Dictionary<uint, int>()
             {
                 { 0, alternatePassiveSkillKeyStone.StatAMinimumValue }
             };
@@ -77,7 +77,7 @@ public class AlternateTreeManager
                 rolledAlternatePassiveSkill = applicableAlternatePassiveSkill;
         }
 
-        Dictionary<uint, (uint minimumRoll, uint maximumRoll)> alternatePassiveSkillStatRollRanges = new Dictionary<uint, (uint minimumRoll, uint maximumRoll)>()
+        Dictionary<uint, (int minimumRoll, int maximumRoll)> alternatePassiveSkillStatRollRanges = new Dictionary<uint, (int minimumRoll, int maximumRoll)>()
         {
             { 0, (rolledAlternatePassiveSkill.StatAMinimumValue, rolledAlternatePassiveSkill.StatAMaximumValue) },
             { 1, (rolledAlternatePassiveSkill.StatBMinimumValue, rolledAlternatePassiveSkill.StatBMaximumValue) },
@@ -85,15 +85,15 @@ public class AlternateTreeManager
             { 3, (rolledAlternatePassiveSkill.StatDMinimumValue, rolledAlternatePassiveSkill.StatDMaximumValue) }
         };
 
-        Dictionary<uint, uint> alternatePassiveSkillStatRolls = new Dictionary<uint, uint>();
+        Dictionary<uint, int> alternatePassiveSkillStatRolls = new Dictionary<uint, int>();
 
         // Capping the maximum iterations at 4 for now.
         for (uint i = 0; i < Math.Min(rolledAlternatePassiveSkill.StatIndices.Count, 4); i++)
         {
-            uint alternatePassiveSkillStatRoll = alternatePassiveSkillStatRollRanges[i].minimumRoll;
+            int alternatePassiveSkillStatRoll = alternatePassiveSkillStatRollRanges[i].minimumRoll;
 
             if (alternatePassiveSkillStatRollRanges[i].maximumRoll > alternatePassiveSkillStatRollRanges[i].minimumRoll)
-                alternatePassiveSkillStatRoll = randomNumberGenerator.Generate(alternatePassiveSkillStatRollRanges[i].minimumRoll, alternatePassiveSkillStatRollRanges[i].maximumRoll);
+                alternatePassiveSkillStatRoll = (int)randomNumberGenerator.Generate((uint)alternatePassiveSkillStatRollRanges[i].minimumRoll, (uint)alternatePassiveSkillStatRollRanges[i].maximumRoll);
 
             alternatePassiveSkillStatRolls.Add(i, alternatePassiveSkillStatRoll);
         }

--- a/Datafile Generator/DatafileGenerator/Source/Program.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Program.cs
@@ -63,7 +63,7 @@ public static class Program
         sb.Clear();
         //begin iterating over the 5 jewel types
         //reverse order since glorious vanity sucks
-        for (int i = 5; i > 0; i--)
+        for (int i = 6; i > 0; i--)
         {
             var sw = Stopwatch.StartNew();
             GetJewelTypeInfo(i, out _, out _, out _, out string outputFile);
@@ -163,6 +163,16 @@ public static class Program
         byte[] header = new byte[maxSeed * nodes.Count];
         //the actual information for the jewels. will convert to 1d later
         byte[][] data2d = new byte[maxSeed * nodes.Count][];
+
+        //re-index our additions and replacements to consider only this jewel type
+        uint numAdditions = (uint)DataManager.AlternatePassiveAdditions.Count;
+        var jewelEffectOptions = DataManager.AlternatePassiveAdditions.Where(x => x.AlternateTreeVersionIndex == 1).Select(x => x.Index)
+            .Concat(DataManager.AlternatePassiveSkills.Where(x => x.AlternateTreeVersionIndex == 1).Select(x => x.Index + numAdditions))
+            .Select((x, i) => new { rid = x, index = (byte)i }).ToDictionary(x => x.rid, x => x.index);
+        if (jewelEffectOptions.Count > 256)
+        {
+            throw new Exception("Cannot safely construct file: possible indices greater than byte size");
+        }
         //nested parallell tasks, in case your cpu wasnt on fire yet
         Parallel.For(0, nodes.Count, nodeIndex =>
         {
@@ -187,19 +197,18 @@ public static class Program
                 //handle might/legacy of the vaal
                 if (skillInfo.AlternatePassiveSkill.Index == LegacyOfTheVaal || skillInfo.AlternatePassiveSkill.Index == MightOfTheVaal)
                 {
-                    //do we want to add the indicator for this being Legacy of the Vaal/Might of the Vaal or just shit out the stats?
-                    //indices.Add((byte)(skillInfo.AlternatePassiveSkill.Index + NumAdditions));
+                    //just shit out the stats, the fact that its legacy/might is implied
                     for (int k = 0; k < skillInfo.AlternatePassiveAdditionInformations.Count; k++)
                     {
                         //add the additions
-                        indices.Add((byte)skillInfo.AlternatePassiveAdditionInformations.ElementAt(k).AlternatePassiveAddition.Index);
+                        indices.Add(jewelEffectOptions[skillInfo.AlternatePassiveAdditionInformations.ElementAt(k).AlternatePassiveAddition.Index]);
                         rolls.Add((byte)skillInfo.AlternatePassiveAdditionInformations.ElementAt(k).StatRolls[0U]);
                     }
                 }
                 //handle all others
                 else
                 {
-                    indices.Add((byte)(skillInfo.AlternatePassiveSkill.Index + NumAdditions));
+                    indices.Add(jewelEffectOptions[skillInfo.AlternatePassiveSkill.Index + numAdditions]);
                     for (int k = 0; k < skillInfo.StatRolls.Count; k++)
                     {
                         rolls.Add((byte)skillInfo.StatRolls[(uint)k]);
@@ -231,6 +240,15 @@ public static class Program
         GetJewelTypeInfo(jewelType, out int jewelMin, out int jewelMax, out int jewelIncrement, out _);
         int maxSeed = (jewelMax - jewelMin) / jewelIncrement + 1;
         byte[] dataInternal = new byte[maxSeed * nodes.Count];
+        //re-index our additions and replacements to consider only this jewel type
+        uint numAdditions = (uint)DataManager.AlternatePassiveAdditions.Count;
+        var jewelEffectOptions = DataManager.AlternatePassiveAdditions.Where(x => x.AlternateTreeVersionIndex == jewelType).Select(x => x.Index)
+            .Concat(DataManager.AlternatePassiveSkills.Where(x => x.AlternateTreeVersionIndex == jewelType).Select(x => x.Index + numAdditions))
+            .Select((x, i) => new { rid = x, index = (byte)i }).ToDictionary(x => x.rid, x => x.index);
+        if (jewelEffectOptions.Count > 256)
+        {
+            throw new Exception("Cannot safely construct file: possible indices greater than byte size");
+        }
         //for non glorious vanity, we only care about notables
         Parallel.For(0, nodes.Count, notableIndex =>
         {
@@ -252,13 +270,11 @@ public static class Program
                 byte passiveSkillIndex = 0;
                 if (flag)
                 {
-                    //replacements get stat rid + count(alternate_passive_additions)
-                    passiveSkillIndex = (byte)(alternateTreeManager.ReplacePassiveSkill().AlternatePassiveSkill.Index + NumAdditions);
+                    passiveSkillIndex = jewelEffectOptions[alternateTreeManager.ReplacePassiveSkill().AlternatePassiveSkill.Index + numAdditions];
                 }
                 else
                 {
-                    //additions get stat rid as is
-                    passiveSkillIndex = (byte)alternateTreeManager.AugmentPassiveSkill().First().AlternatePassiveAddition.Index;
+                    passiveSkillIndex = jewelEffectOptions[alternateTreeManager.AugmentPassiveSkill().First().AlternatePassiveAddition.Index];
                 }
                 dataInternal[notableIndex * maxSeed + jewel_index] = passiveSkillIndex;
             });
@@ -299,6 +315,12 @@ public static class Program
                 jewelMax = 160000;
                 jewelIncrement = 20;
                 jewelName = "ElegantHubris";
+                break;
+            case 6:
+                jewelMin = 100;
+                jewelMax = 8000;
+                jewelIncrement = 1;
+                jewelName = "HeroicTragedy";
                 break;
             default:
                 ExitWithError($"Unrecognized jewel type code: [yellow]{jewelType}[/].");
@@ -366,7 +388,7 @@ public static class Program
             });
         response = AnsiConsole.Prompt(fileTextPrompt);
     }
-    
+
     private static void PromptUserForChoice(string query, List<string> choices, out int response)
     {
         SelectionPrompt<string> fileTextPrompt = new SelectionPrompt<string>().Title(query);

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Using the data files
 
-### Parsing Brutal Restraint, Elegant Hubris, Lethal Pride, and Militant Faith
+### Parsing Brutal Restraint, Elegant Hubris, Lethal Pride, Militant Faith, and Heroic Tragedy
 
-Data files are uint8 arrays (1 byte per node+seed) in a pure binary format, where array\[node_id_INDEX \* jewel_seed_Size + jewel_seed_offset\] = index_of_Change
+Data files are uint8 arrays (1 byte per node+seed) in a pure binary format, where array\[node_id_INDEX \* jewel_seed_Size + jewel_seed_offset\] = index_of_change
 
 	node_id_INDEX is given by Node_Indices.csv
 	jewel_seed_Size is the number of seeds for a given jewel (note elegant hubris seeds are divided by 20)
@@ -10,12 +10,14 @@ Data files are uint8 arrays (1 byte per node+seed) in a pure binary format, wher
 
 A list of which nodes are in range of what jewel socket can be found in Jewel_Node_Link.json
 
-Also note that Node_Indices.csv contains indices for all modifiable nodes, but the non-Glorious Vanity jewels will only have data for notables (indices 0 to 390). Modifications to non-notables for these jewels are constant and thus have been omitted from their data files to save space.
+Also note that Node_Indices.csv contains indices for all modifiable nodes, but the non-Glorious Vanity jewels will only have data for notables. Modifications to non-notables for these jewels are constant and thus have been omitted from their data files to save space.
 
-index_of_Change is dependant on value, 
+to find index_of_change:
 
-	additions are index_of_Change = _rid in alternate_passive_additions.json
-	replacements are index_of_Change - 94 = _rid in alternate_passive_skills.json
+  parse alternate_passive_additions.json selecting only the entries that match the jewel type, ordered by _rid
+  parse alternate_passive_skills.json selecting only the entries that match the jewel type, ordered by _rid
+  concatenate the two, placing alternate_passive_additions before those of alternate_passive_skills
+  entry with index index_of_change will be the stat that was selected
 
 Non-Glorious Vanity jewels are relatively simple to parse with this definition:
 
@@ -40,8 +42,12 @@ like before:
 	jewel_seed_Size is the number of seeds for a given jewel
 	jewel_seed_offset is the value above the minimum
 
-	additions are index_of_Change = _rid in alternate_passive_additions.json
-	replacements are index_of_Change - 94 = _rid in alternate_passive_skills.json
+to find index_of_change:
+
+  parse alternate_passive_additions.json selecting only the entries that match the jewel type, ordered by _rid
+  parse alternate_passive_skills.json selecting only the entries that match the jewel type, ordered by _rid
+  concatenate the two, placing alternate_passive_additions before those of alternate_passive_skills
+  entry with index index_of_change will be the stat that was selected
 
 and data files are in a pure binary format with one byte per piece of information; however, with glorious vanity, each node requires multiple pieces of information.
 
@@ -52,7 +58,7 @@ For a jewel, each node can have multiple changes, and each change comes with 1 o
 
 To know the length of the header, we have the additional definition:
 
-	nodeCount is the number of nodes in the Node_Indices.csv (currently 1678)
+	nodeCount is the number of nodes in the Node_Indices.csv
 
 Because each node has more than 1 value associated with it, the recommended method for parsing it is a header array and a 2d array of data as follows:
 - create a header of size: nodeCount \* maxSeedIndex
@@ -99,4 +105,4 @@ It's built on top of a timeless jewel simulator, so its not very consice, but th
 
 It will need an alternate passive additions json, an alternate passive skills json, and the most recent skill tree json. You'll also have to tell it where to output and whether you want the compressed or uncompressed files.    
 
-Running it will output 5 datafiles, 1 lua file, and 1 csv file (note that if compressed, the Glorious Vanity "file" will actually come out to be multiple files each with size at most 5MB due to the limitations within Path of Building).
+Running it will output 6 datafiles, 1 lua file, and 1 csv file (note that if compressed, the Glorious Vanity "file" will actually come out to be multiple files each with size at most 5MB due to the limitations within Path of Building).


### PR DESCRIPTION
New jewel introduced two key problems: it has negative stats and it increased the number of total changes beyond the byte limit. To account for the former, just changed some types to be signed. To account for the latter, re-indexes the _rid values for each jewel so that it only counts the changes a given jewel type can make instead of the changes any jewel could make. This is a breaking change and will require changes to integration for anyone making use of these data files.

Updated the readme and basic parse/search example too